### PR TITLE
Fix 'Liked Songs,' cache Spotify User ID

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -108,7 +108,8 @@ typedef struct {
 } ExploreItem_t;
 
 typedef struct {
-  char name[64] = "";
+  char displayName[64] = "";
+  char id[64]           = "";
   char refreshToken[150] = "";
   bool selected = false;
   char selectedDeviceId[64] = "";


### PR DESCRIPTION
The fix made for #7 actually never worked for me, but I had given away my device as a gift soon after anyway.

Now that I remade one for myself, I quickly fixed the underlying issue (using the Spotify User's `display_name` instead of their `id`)

Spotify API reporting the ID as part of the playlist URI:

![image](https://github.com/quadule/knobby/assets/20761757/372d607d-61ae-4085-b9cd-b4c3c7d8b48c)

This should also request the user's ID if it wasn't already cached (for people who update). :)